### PR TITLE
use tryParseNativeAs instead of tryParseAs

### DIFF
--- a/src/Client/Library.fs
+++ b/src/Client/Library.fs
@@ -95,7 +95,7 @@ type BridgeConfig<'Msg,'ElmishMsg> =
                     Dom.window.setTimeout
                         ((fun () -> websocket timeout server), timeout, ()) |> ignore
                 socket.onmessage <- fun e ->
-                         Json.tryParseAs(string e.data)
+                         Json.tryParseNativeAs(string e.data)
                          |> function
                             | Ok msg -> msg |> this.mapping |> dispatch
                             | _ -> ()


### PR DESCRIPTION
see https://github.com/Zaid-Ajaj/Fable.SimpleJson/issues/40#issuecomment-562646423

``tryParseAs`` uses a custom json parser and does not support scientific notation (``-4.5474735088646412E-13``).

``tryParseNativeAs`` does.