### PR TITLE
Updated asSubscription helper for Elmish v4.

### DIFF
--- a/src/Client/Elmish.Bridge.Client.fsproj
+++ b/src/Client/Elmish.Bridge.Client.fsproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>fsharp;fable;elmish;remoting;rpc;webserver</PackageTags>
     <Authors>Diego Esmerio</Authors>
-    <Version>7.0.2</Version>
+    <Version>7.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/src/Client/Library.fs
+++ b/src/Client/Library.fs
@@ -322,8 +322,11 @@ module Bridge =
 
     /// Creates a subscription to be used with `Cmd.OfSub`. That enables starting Bridge with
     /// a configuration obtained after the `Program` has already started
-    let inline asSubscription (this:BridgeConfig<_,_>) dispatch =
-        this.Attach dispatch
+    let inline asSubscription (this:BridgeConfig<_,_>) =
+        let sub dispatch =
+            this.Attach dispatch
+            {new System.IDisposable with member _.Dispose() = ()}
+        [ ["Elmish";"Bridge"], sub ]
 
     /// Enables using Elmish.Bridge with any function that can receive compatible messages.
     /// This includes React hooks, Lit and Svelte

--- a/src/DotnetClient/Elmish.Bridge.DotnetClient.fsproj
+++ b/src/DotnetClient/Elmish.Bridge.DotnetClient.fsproj
@@ -8,7 +8,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;dotnet;elmish;remoting;rpc;webserver</PackageTags>
     <Authors>Diego Esmerio</Authors>
-    <Version>7.0.1</Version>
+    <Version>7.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/src/DotnetClient/Library.fs
+++ b/src/DotnetClient/Library.fs
@@ -265,25 +265,40 @@ module Bridge =
                     | _ -> ws.Value <- None, true
             }
 
-    /// Creates a subscription to be used with `Cmd.OfSub`. That enables starting Bridge with
+    /// Creates an effect to be used with `Cmd.OfEffect`. That enables starting Bridge with
     /// a configuration after the `Program` has already started
     let asSubscription (this:BridgeConfig<_,_>) =
        fun dispatch -> attach this dispatch |> ignore
 
+    /// Creates a subscription compatible with Elmish v4. Takes a function that returns an optional `BridgeConfig` based on the model.
+    /// If the function returns `None`, the subscription is not started. If it returns `Some`, the subscription is started with the resulting configuration.
+    let inline asModelConfigSubscription (configurator: 'model -> BridgeConfig<_,_> option) model : Sub<'msg> =
+       configurator model 
+       |> Option.map(fun config -> ("Elmish"::"Bridge"::(Option.toList config.name), attach config))
+       |> Option.toList
+
+    /// Enables using Elmish.Bridge with any function that can receive compatible messages.
+    let inline onCustomDispatcher dispatch (this:BridgeConfig<_,_>) =
+        attach this dispatch
+
 
 [<RequireQualifiedAccess>]
 module Program =
-
-    /// Apply the `Bridge` to be used with the program.
+    /// Apply the `Bridge` to be used with the program using a function that returns an optional `BridgeConfig` taking the model.
+    /// If the function returns `None`, the subscription is not started. If it returns `Some`, the subscription is started with the resulting configuration.
     /// Preferably use it before any other operation that can change the type of the message passed to the `Program`.
-    let withBridge endpoint (program : Program<_, _, _, _>) =
-        program |> Program.mapSubscription (fun prev m -> (["Elmish";"Bridge"], fun dispatch -> let config = (Bridge.endpoint endpoint) in Bridge.attach config dispatch) :: (prev m))
+    let inline withBridgeConfigurator (config: _ -> BridgeConfig<_,_> option) (program : Program<_, _, _, _>) =
+       program |> Program.mapSubscription (fun prev m -> Bridge.asModelConfigSubscription config m @ prev m)    
 
-    /// Apply the `Bridge` to be used with the program.
+    /// Apply the `Bridge` to be used with the program using the `BridgeConfig` as argument.
     /// Preferably use it before any other operation that can change the type of the message passed to the `Program`.
-    let withBridgeConfig (config:BridgeConfig<_,_>) (program : Program<_, _, _, _>) =
-        program |> Program.mapSubscription(fun prev m -> ("Elmish"::"Bridge"::(config.name |> Option.map List.singleton |> Option.defaultValue []), fun dispatch -> Bridge.attach config dispatch) :: (prev m))
+    let inline withBridgeConfig (config:BridgeConfig<_,_>) (program : Program<_, _, _, _>) =
+       program |> withBridgeConfigurator (fun _ -> Some config)  
 
+    /// Apply the `Bridge` to be used with the program using the endpoint as argument.
+    /// Preferably use it before any other operation that can change the type of the message passed to the `Program`.
+    let inline withBridge endpoint (program : Program<_, _, _, _>) =
+        program |> withBridgeConfig (Bridge.endpoint(endpoint)) 
 
 [<RequireQualifiedAccess>]
 module Cmd =
@@ -295,7 +310,7 @@ module Cmd =
 [<AutoOpen>]
 module RPC =
 
-    type RPC.IReplyChannel<'T> with
+  type RPC.IReplyChannel<'T> with
     member t.Reply(v:'T) =
         Bridge.rpcSender(t.ValueId, v, None)
     member t.ReplyNamed(name, v:'T) =


### PR DESCRIPTION
This PR updates asSubscription helper method for changes in Elmish v4.

Elmish subscriptions have been revised in v.4, and there is a migration guide:
https://elmish.github.io/elmish/docs/subscription.html#migrating-from-v3

NB! asSubscription helper method is also defined in DotNetClient library, but I am note sure if it needs a similar change. @Nhowka Please check if DotNetLibrary method needs an update.