### PR TITLE
Handle large messages received by Suave server

### DIFF
--- a/src/Suave/Library.fs
+++ b/src/Suave/Library.fs
@@ -28,8 +28,7 @@ module Suave =
                     while loop do
                         let! msg = webSocket.read()
                         match msg with
-                        | Continuation, data, complete 
-                        | Text, data, complete ->
+                        | (Continuation | Text), data, complete 
                             if complete then
                                 let completeData =
                                     match buffer with
@@ -48,12 +47,7 @@ module Suave =
                             let emptyResponse = [||] |> ByteSegment
                             do! webSocket.send Close emptyResponse true
                             loop <- false
-                        | _ ->
-#if DEBUG
-                            let msg = sprintf "Unhandled message: %A" msg
-                            System.Diagnostics.Debugger.Break()
-#endif
-                            ()
+                        | _ -> ()
                 }
 
             async {

--- a/src/Suave/Library.fs
+++ b/src/Suave/Library.fs
@@ -28,20 +28,32 @@ module Suave =
                     while loop do
                         let! msg = webSocket.read()
                         match msg with
+                        | Continuation, data, complete 
                         | Text, data, complete ->
-                            buffer <- data :: buffer
                             if complete then
-                                buffer
-                                |> List.rev
-                                |> Array.concat
+                                let completeData =
+                                    match buffer with
+                                    | [] -> data
+                                    | xs ->
+                                        buffer <- []
+                                        (data :: xs) |> List.rev |> Array.concat
+
+                                completeData
                                 |> UTF8.toString
                                 |> sender
-                                buffer <- []
+                            else
+                                buffer <- data :: buffer
+                                
                         | (Close, _, _) ->
                             let emptyResponse = [||] |> ByteSegment
                             do! webSocket.send Close emptyResponse true
                             loop <- false
-                        | _ -> ()
+                        | _ ->
+#if DEBUG
+                            let msg = sprintf "Unhandled message: %A" msg
+                            System.Diagnostics.Debugger.Break()
+#endif
+                            ()
                 }
 
             async {


### PR DESCRIPTION
This change fixes a bug that messages would never complete and be received by the server when they were large.

- Adds handling for the `Continuation` case which occurs when receiving large (empirically >64kB) messages. 
- Makes minor optimization to avoid `list` allocation in the common case of a single `data` element
- Adds a `Break()` to pick up any other unhandled messages in `DEBUG` mode. This code was how I identified the bug but happy to delete it. 
